### PR TITLE
Better handle whitespace and newline characters 

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "ppx_deriving_cmdliner"
-version: "0.4.1"
+version: "0.4.1-dev"
 maintainer: "Isaac Hodes <isaachodes@gmail.com>"
 authors: [ "Isaac Hodes <isaachodes@gmail.com>" ]
 license: "MIT"

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "ppx_deriving_cmdliner"
-version: "0.4.0"
+version: "0.4.1"
 maintainer: "Isaac Hodes <isaachodes@gmail.com>"
 authors: [ "Isaac Hodes <isaachodes@gmail.com>" ]
 license: "MIT"


### PR DESCRIPTION
With these changes, we now:

- trim whitespaces at the end 
- use a smarter printer to not trouble `$PAGER`s with new lines

Before: 
![](https://cl.ly/2Q031s0x0V2I/[ea4f5d1e577f432121c2fc7fa9e78639]_Image%202017-06-25%20at%201.48.03%20PM.png)

After:
![](https://cl.ly/290f0X2h2h1A/[ae0766f75af91f527101d94e9f7f03ad]_Image%202017-06-25%20at%201.59.24%20PM.png)

and no more https://github.com/hammerlab/epidisco/issues/191.