### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [@@deriving cmdliner]
 
-_deriving Cmdliner_ is the easiest way to get a command line interface.
+_deriving Cmdliner_ is a simple way to get a command line interface.
 
 It is also a [ppx_deriving](https://github.com/whitequark/ppx_deriving) plugin
 that generates a [Cmdliner](https://github.com/dbuenzli/cmdliner) `Term` for a


### PR DESCRIPTION
The previous readme was too presumptuous. :)
Everybody knows that the simplest way to get a command line interface for an OCaml program is to use the minicli library.
And yes, minicli does not generate a manpage for you, and yes it takes seconds with minicli
to add a new option or change an existing one, which is just wonderful when prototyping software.
Also, minicli makes it difficult to use a CLI incorrectly. Something which is quite interesting for scientific
software and that I found nowhere else. :)