### PR TITLE
Enable OCaml 4.10.0. (Fixes #40.)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ env:
     - OCAML_VERSION=4.04 PACKAGE="ppx_deriving_cmdliner" TESTS=true
     - OCAML_VERSION=4.05 PACKAGE="ppx_deriving_cmdliner" TESTS=true
     - OCAML_VERSION=4.06 PACKAGE="ppx_deriving_cmdliner" TESTS=true
+    - OCAML_VERSION=4.07 PACKAGE="ppx_deriving_cmdliner" TESTS=true
+    - OCAML_VERSION=4.08 PACKAGE="ppx_deriving_cmdliner" TESTS=true
+    - OCAML_VERSION=4.09 PACKAGE="ppx_deriving_cmdliner" TESTS=true
+    - OCAML_VERSION=4.10 PACKAGE="ppx_deriving_cmdliner" TESTS=true
+    - OCAML_VERSION=4.11 PACKAGE="ppx_deriving_cmdliner" TESTS=true
 os:
 - linux
 - osx

--- a/dune-workspace.dev
+++ b/dune-workspace.dev
@@ -5,3 +5,6 @@
 (context (opam (switch 4.06.0)))
 (context (opam (switch 4.07.0)))
 (context (opam (switch 4.08.0)))
+(context (opam (switch 4.09.0)))
+(context (opam (switch 4.10.0)))
+(context (opam (switch 4.11.0)))

--- a/src/ppx_deriving_cmdliner.cppo.ml
+++ b/src/ppx_deriving_cmdliner.cppo.ml
@@ -12,6 +12,12 @@
 #define Mknoloc_option(x) (Some x)
 #endif
 
+#if OCAML_VERSION < (4, 11, 0)
+#define Pconst_string_argument(s, l) (s, None)
+#else
+#define Pconst_string_argument(s, l) (s, l, None)
+#endif
+
 open Longident
 open Location
 open Asttypes
@@ -307,7 +313,7 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let ty = Typ.poly poly_vars (polymorphize_ser [%type: unit -> [%t typ] Cmdliner.Term.t]) in
       let default_fun =
         let type_path = String.concat "." (path @ [type_decl.ptype_name.txt]) in
-        let e_type_path = Exp.constant (Pconst_string (type_path, None)) in
+        let e_type_path = Exp.constant (Pconst_string Pconst_string_argument(type_path, loc)) in
         [%expr fun _ ->
           invalid_arg ("ppx_deriving_cmdliner: Maybe a [@@deriving cmdliner] is missing when extending the type "^
                        [%e e_type_path])]

--- a/src/ppx_deriving_cmdliner.cppo.ml
+++ b/src/ppx_deriving_cmdliner.cppo.ml
@@ -286,7 +286,7 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let ser = ser_expr_of_typ manifest [] "" in
       let lid = Ppx_deriving.mangle_lid (`PrefixSuffix ("M", "cmdliner_term")) lid in
       let orig_mod = Mod.ident (mknoloc lid) in
-      ([Str.module_ (Mb.mk (mknoloc mod_name) orig_mod)],
+      ([Str.module_ (Mb.mk (mknoloc (Some mod_name)) orig_mod)],
        [Vb.mk (pvar to_cmdliner_name)
               (polymorphize [%expr ([%e ser] : unit -> [%t typ] Cmdliner.Term.t)])])
     | Some _ ->
@@ -318,7 +318,7 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let flid = lid (Printf.sprintf "%s.f" mod_name) in
       let field = Exp.field (Exp.ident flid) (flid) in
       let mod_ =
-        Str.module_ (Mb.mk (mknoloc mod_name)
+        Str.module_ (Mb.mk (mknoloc (Some mod_name))
                        (Mod.structure [
                            Str.type_ Type_Nonrecursive [typ];
           Str.value Nonrecursive [record];
@@ -448,7 +448,7 @@ let ser_sig_of_type ~options ~path type_decl =
     in
     let record = Val.mk (mknoloc "f") (Typ.constr (lid "t_cmdliner_term") []) in
     let mod_ =
-      Sig.module_ (Md.mk (mknoloc mod_name)
+      Sig.module_ (Md.mk (mknoloc (Some mod_name))
                   (Mty.signature [
                      Sig.type_ Type_Nonrecursive [typ];
         Sig.value record;

--- a/src/ppx_deriving_cmdliner.cppo.ml
+++ b/src/ppx_deriving_cmdliner.cppo.ml
@@ -6,6 +6,12 @@
 #define Type_Nonrecursive Nonrecursive
 #endif
 
+#if OCAML_VERSION < (4, 10, 0)
+#define Mknoloc_option(x) x
+#else
+#define Mknoloc_option(x) (Some x)
+#endif
+
 open Longident
 open Location
 open Asttypes
@@ -286,7 +292,7 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let ser = ser_expr_of_typ manifest [] "" in
       let lid = Ppx_deriving.mangle_lid (`PrefixSuffix ("M", "cmdliner_term")) lid in
       let orig_mod = Mod.ident (mknoloc lid) in
-      ([Str.module_ (Mb.mk (mknoloc (Some mod_name)) orig_mod)],
+      ([Str.module_ (Mb.mk (mknoloc Mknoloc_option(mod_name)) orig_mod)],
        [Vb.mk (pvar to_cmdliner_name)
               (polymorphize [%expr ([%e ser] : unit -> [%t typ] Cmdliner.Term.t)])])
     | Some _ ->
@@ -318,7 +324,7 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let flid = lid (Printf.sprintf "%s.f" mod_name) in
       let field = Exp.field (Exp.ident flid) (flid) in
       let mod_ =
-        Str.module_ (Mb.mk (mknoloc (Some mod_name))
+        Str.module_ (Mb.mk (mknoloc Mknoloc_option(mod_name))
                        (Mod.structure [
                            Str.type_ Type_Nonrecursive [typ];
           Str.value Nonrecursive [record];
@@ -448,7 +454,7 @@ let ser_sig_of_type ~options ~path type_decl =
     in
     let record = Val.mk (mknoloc "f") (Typ.constr (lid "t_cmdliner_term") []) in
     let mod_ =
-      Sig.module_ (Md.mk (mknoloc (Some mod_name))
+      Sig.module_ (Md.mk (mknoloc Mknoloc_option(mod_name))
                   (Mty.signature [
                      Sig.type_ Type_Nonrecursive [typ];
         Sig.value record;


### PR DESCRIPTION
Enable OCaml 4.10.0 support with new mknod call signature for PPX AST manipulation.

Just managed to get this going under 4.10.0. I really appreciate your work on this package. It is the closest thing to Rust's structopt on OCaml, and it is a pleasure to use!