### PR TITLE
Port to ppxlib

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,0 @@
-B _build/**
-S _src/**
-
-PKG compiler-libs.common ppx_deriving.api ppx_import result ppx_tools.metaquot cmdliner alcotest

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - OCAML_VERSION=4.09 PACKAGE="ppx_deriving_cmdliner" TESTS=true
     - OCAML_VERSION=4.10 PACKAGE="ppx_deriving_cmdliner" TESTS=true
     - OCAML_VERSION=4.11 PACKAGE="ppx_deriving_cmdliner" TESTS=true
+    - OCAML_VERSION=4.12 PACKAGE="ppx_deriving_cmdliner" TESTS=true
 os:
 - linux
 - osx

--- a/descr
+++ b/descr
@@ -1,4 +1,0 @@
-Cmdliner.Term.t generator
-
-ppx_deriving_cmdliner is a ppx_deriving plugin that generates
-a Cmdliner Term.t for a record type.

--- a/ppx_deriving_cmdliner.opam
+++ b/ppx_deriving_cmdliner.opam
@@ -29,7 +29,6 @@ depends: [
   "dune"
   "ppxlib"       {>= "0.14.0"}
   "alcotest"     {with-test}
-  "ppx_import"   {with-test & >= "1.1"}
 ]
 synopsis: "Cmdliner.Term.t generator"
 description: """

--- a/ppx_deriving_cmdliner.opam
+++ b/ppx_deriving_cmdliner.opam
@@ -22,12 +22,12 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
-  "cmdliner" {>= "1.0.0"}
+  "ocaml"        {>= "4.03"}
+  "cmdliner"     {>= "1.0.0"}
   "result"
   "ppx_deriving" {>= "5.0"}
   "dune"
-  "ppxlib"      {>= "0.18.0"}
+  "ppxlib"       {>= "0.14.0"}
   "alcotest"     {with-test}
   "ppx_import"   {with-test & >= "1.1"}
 ]

--- a/ppx_deriving_cmdliner.opam
+++ b/ppx_deriving_cmdliner.opam
@@ -15,7 +15,7 @@ license: "MIT"
 version: "0.5.1-dev"
 tags: ["syntax" "cli"]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [
@@ -25,11 +25,9 @@ depends: [
   "ocaml" {>= "4.03"}
   "cmdliner" {>= "1.0.0"}
   "result"
-  "ppx_deriving" {>= "4.0" & < "5.0"}
-  "dune"         {build}
-  "ocamlfind"    {build}
-  "ppxfind"      {build}
-  "cppo"         {build}
+  "ppx_deriving" {>= "5.0"}
+  "dune"
+  "ppxlib"      {>= "0.18.0"}
   "alcotest"     {with-test}
   "ppx_import"   {with-test & >= "1.1"}
 ]
@@ -37,9 +35,4 @@ synopsis: "Cmdliner.Term.t generator"
 description: """
 ppx_deriving_cmdliner is a ppx_deriving plugin that generates
 a Cmdliner Term.t for a record type."""
-#url {
-#  src:
-#    "https://github.com/hammerlab/ppx_deriving_cmdliner/archive/v0.4.0.tar.gz"
-#  checksum: "md5=24a29008621860e05544c931b11272de"
-#}
 

--- a/src/dune
+++ b/src/dune
@@ -1,10 +1,3 @@
-(rule
- (deps
-  (:< ppx_deriving_cmdliner.cppo.ml))
- (targets ppx_deriving_cmdliner.ml)
- (action
-  (run %{bin:cppo} -V OCAML:%{ocaml_version} %{<} -o %{targets})))
-
 (library
  (name ppx_deriving_cmdliner_runtime)
  (public_name ppx_deriving_cmdliner.runtime)
@@ -17,10 +10,8 @@
  (public_name ppx_deriving_cmdliner)
  (synopsis "[@@deriving cmdliner]")
  (libraries ppx_deriving.api)
- (preprocess
-  (action
-   (run ppxfind -legacy ppx_tools.metaquot --as-pp %{input-file})))
- (ppx_runtime_libraries ppx_deriving_cmdliner_runtime cmdliner)
- (flags :standard -w -9-27-39)
+ (preprocess (pps ppxlib.metaquot))
+ (ppx_runtime_libraries ppx_deriving_cmdliner.runtime cmdliner)
+ (flags :standard -w -9-16-27-39)
  (modules ppx_deriving_cmdliner)
  (kind ppx_deriver))

--- a/src/ppx_deriving_cmdliner.ml
+++ b/src/ppx_deriving_cmdliner.ml
@@ -128,7 +128,6 @@ let rec converter_for ?list_sep ?enum typ =
 
 
 let rec docv_for ?list_sep typ =
-  (* let loc = typ.ptyp_loc in *)
   let s = (match list_sep with None -> ',' | Some s -> s) in
   match typ with
   | [%type: int] -> "INT"


### PR DESCRIPTION
This should make it compatible with recent compiler and recent ppx_deriving. Should fix #47 (and also #42, at least this works perfectly fine with dune 2.0 for me)