### PR TITLE
Ppxlib.0.26.0 compatibility

### DIFF
--- a/ppx_deriving_cmdliner.opam
+++ b/ppx_deriving_cmdliner.opam
@@ -24,7 +24,7 @@ run-test: [
 ]
 depends: [
   "ocaml"        {>= "4.05"}
-  "cmdliner"     {>= "1.0.0"}
+  "cmdliner"     {>= "1.0.0" & < "1.0.1"}
   "result"
   "ppx_deriving" {>= "5.0"}
   "dune"

--- a/ppx_deriving_cmdliner.opam
+++ b/ppx_deriving_cmdliner.opam
@@ -28,7 +28,7 @@ depends: [
   "result"
   "ppx_deriving" {>= "5.0"}
   "dune"
-  "ppxlib"       {>= "0.18.0"}
+  "ppxlib"       {>= "0.26.0"}
   "alcotest"     {with-test}
 ]
 synopsis: "Cmdliner.Term.t generator"

--- a/src/ppx_deriving_cmdliner.ml
+++ b/src/ppx_deriving_cmdliner.ml
@@ -387,7 +387,9 @@ let ser_str_of_type_ext ~options ~path ({ ptyext_path = { loc }} as type_ext) =
           (* nothing to do, since the constructor must be handled in original
              constructor declaration *)
           acc_cases
-        | Pext_decl (pext_args, _) ->
+        | Pext_decl (_ :: _, _, _) ->
+          raise_errorf ~loc "%s: Explicit binders for type variables not supported" deriver
+        | Pext_decl ([], pext_args, _) ->
           let json_name = attr_string "name" name' pext_attributes in
           let case =
             match pext_args with


### PR DESCRIPTION
This is a patch PR to make the PPX compatible with ppxlib.0.26.0 which has bumped the AST to 4.14/5.00.